### PR TITLE
Design updates: highlighted lists & subtitle redesign

### DIFF
--- a/studio/schemas/objects/bodyPortableText.js
+++ b/studio/schemas/objects/bodyPortableText.js
@@ -56,6 +56,11 @@ export default {
       type: 'embed',
       name: 'embed',
       title: 'Code Embed'
+    },
+    {
+      type: 'highlighted',
+      name: 'highlighted',
+      title: 'Highlighted'
     }
   ]
 }

--- a/studio/schemas/objects/embed.js
+++ b/studio/schemas/objects/embed.js
@@ -1,7 +1,10 @@
+import MdCode from 'react-icons/lib/md/code'
+
 export default {
   name: 'embed',
   type: 'object',
   title: 'Embed code',
+  icon: MdCode,
   fields: [
     {
       name: 'code',

--- a/studio/schemas/objects/highlighted.js
+++ b/studio/schemas/objects/highlighted.js
@@ -1,0 +1,26 @@
+import MdTexture from 'react-icons/lib/md/texture'
+
+export default {
+  name: 'highlighted',
+  type: 'object',
+  title: 'Highlighted list',
+  icon: MdTexture,
+  fields: [
+    {
+      name: 'title',
+      type: 'string',
+      title: 'Title  (optional)'
+    },
+    {
+      name: 'list',
+      type: 'array',
+      title: 'List',
+      validation: Rule => Rule.required(),
+      of: [
+        {
+          type: 'string'
+        }
+      ]
+    }
+  ]
+}

--- a/studio/schemas/objects/mainImage.js
+++ b/studio/schemas/objects/mainImage.js
@@ -1,7 +1,10 @@
+import MdImage from 'react-icons/lib/md/image'
+
 export default {
   name: 'mainImage',
   type: 'image',
   title: 'Image',
+  icon: MdImage,
   options: {
     hotspot: true
   },

--- a/studio/schemas/objects/videoLink.js
+++ b/studio/schemas/objects/videoLink.js
@@ -1,7 +1,10 @@
+import MdVideoCall from 'react-icons/lib/md/video-call'
+
 export default {
   name: 'videoLink',
   type: 'object',
   title: 'Video Embed (URL)',
+  icon: MdVideoCall,
   fields: [
     {
       name: 'href',

--- a/studio/schemas/schema.js
+++ b/studio/schemas/schema.js
@@ -25,6 +25,7 @@ import embed from './objects/embed'
 import projectSettings from './documents/projectSettings'
 import postSettings from './documents/postSettings'
 import infoPage from './documents/infoPage'
+import highlighted from './objects/highlighted'
 
 // Then we give our schema to the builder and provide the result to Sanity
 export default createSchema({
@@ -52,7 +53,8 @@ export default createSchema({
     videoLink,
     audioLink,
     embed,
-    infoPage
+    infoPage,
+    highlighted
 
     // When added to this list, object types can be used as
     // { type: 'typename' } in other document schemas

--- a/web/_includes/layouts/home.css
+++ b/web/_includes/layouts/home.css
@@ -224,6 +224,11 @@
     margin-bottom: 5rem;
 }
 
+.projects-page h1, .archive h1 {
+    font-size: 3rem;
+    margin-bottom: 1rem;
+}
+
 @media screen and (max-width: 1000px) {
     .home .cta-block .left {
         top: 0;

--- a/web/_includes/layouts/post.css
+++ b/web/_includes/layouts/post.css
@@ -24,7 +24,7 @@ article h1 {
 }
 
 article .title-wrapper {
-    margin-bottom: 8rem;
+    margin-bottom: 1rem;
 }
 
 article .title-wrapper h2 {
@@ -33,37 +33,27 @@ article .title-wrapper h2 {
     margin-top: 0rem;
 }
 
-article .title-wrapper:after {
-    content: " ";
-    display: block;
-    width: 100%;
-    max-width: 333px;
-    height: 0.75rem;
-    background-image: radial-gradient(at top left, var(--brand-color-1) 10%, transparent 10%),
-        radial-gradient(at top right, var(--brand-color-1) 10%, transparent 10%),
-        radial-gradient(at bottom left, var(--brand-color-1) 10%, transparent 10%),
-        radial-gradient(at bottom right, var(--brand-color-1) 10%, transparent 10%),
-        radial-gradient(var(--brand-color-1) 20%, transparent 20%);
-    background-size: 3px 3px;
-    position: absolute;
-    margin: 2rem 0;
-}
-
 article h2 {
     margin-top: 3rem;
+    --pattern: var(--font-color);
 
-    background-image: linear-gradient(var(--background-color), var(--background-color)),
-        radial-gradient(at top left, var(--brand-color-1) 10%, transparent 10%),
-        radial-gradient(at top right, var(--brand-color-1) 10%, transparent 10%),
-        radial-gradient(at bottom left, var(--brand-color-1) 10%, transparent 10%),
-        radial-gradient(at bottom right, var(--brand-color-1) 10%, transparent 10%),
-        radial-gradient(var(--brand-color-1) 20%, transparent 20%);
-    background-size: 100% 100%, 3px 3px, 3px 3px, 3px 3px, 3px 3px, 3px 3px;
-    background-repeat: no-repeat, repeat, repeat, repeat, repeat, repeat;
-    background-position: 1rem 0, 0 0, 0 0, 0 0, 0 0, 0 0;
+    background-image: linear-gradient(var(--pattern), var(--pattern)),
+        linear-gradient(var(--background-color), var(--background-color)),
+        radial-gradient(at top left, var(--pattern) 10%, transparent 10%),
+        radial-gradient(at top right, var(--pattern) 10%, transparent 10%),
+        radial-gradient(at bottom left, var(--pattern) 10%, transparent 10%),
+        radial-gradient(at bottom right, var(--pattern) 10%, transparent 10%),
+        radial-gradient(var(--pattern) 20%, transparent 20%);
+    
+    background-size: 3px 100%, 100% 100%, 3px 3px, 3px 3px, 3px 3px, 3px 3px, 3px 3px;
+    background-repeat: no-repeat, no-repeat, repeat, repeat, repeat, repeat, repeat;;
+    background-position: calc(0.75rem - 3px) 0, 0.75rem 0, 0 0, 0 0, 0 0, 0 0, 0 0;
     padding-left: 1.5rem;
 }
 
+article.services-page h2 {
+    --pattern: var(--brand-color-1);
+}
 
 article p a {
     color: var(--font-color);
@@ -113,6 +103,16 @@ article hr {
     border-bottom: 1px solid var(--font-color);
     height: 1px;
     opacity: 0.5;
+}
+
+article .post-body hr {
+    margin: 2rem 0;
+}
+
+.highlighted {
+    background-color: var(--brand-color-5);
+    padding: 2rem;
+    margin: 1rem 0;
 }
 
 .resources {

--- a/web/_includes/layouts/post.njk
+++ b/web/_includes/layouts/post.njk
@@ -12,7 +12,7 @@ templateClass: tmpl-post
     {% endif %}
   </div>
 
-  <div class="xnarrow">
+  <div class="narrow post-body">
     {{ post.body | markdownify | safe }}
 
     {% if post.author %}

--- a/web/_includes/layouts/project.njk
+++ b/web/_includes/layouts/project.njk
@@ -27,12 +27,12 @@ templateClass: tmpl-project
     </div>
   {% endif %}
 
-  <div class="xnarrow">
+  <div class="narrow post-body">
     {{ project.body | markdownify | safe }}
   </div>
 
   {% if project.storyboard %}
-    <div class="narrow image-gallery">
+    <div class="wide image-gallery">
       {{ project.storyboard | markdownify | safe }}
     </div>
   {% endif %}

--- a/web/_includes/variables.css
+++ b/web/_includes/variables.css
@@ -6,7 +6,7 @@
     --brand-color-2: #FF9A6E;
     --brand-color-3: #FFFEEE;
     --brand-color-4: #FB8DE3;
-    --brand-color-5: #9ED9C8;
+    --brand-color-5: #ace6bb;
 
     --category-color: #4DD1A4;
     --shadow-color: #F3835E;

--- a/web/archive.njk
+++ b/web/archive.njk
@@ -6,7 +6,7 @@ permalink: /journal/
 
 <div class="wide archive">
   <div class="narrow">
-    <h2>{{journalSettings.title}}</h2>
+    <h1>{{journalSettings.title}}</h1>
     <p class="large-text">
       {{journalSettings.description}}
     </p>

--- a/web/projects.njk
+++ b/web/projects.njk
@@ -6,7 +6,7 @@ permalink: /projects/
 
 <div class="projects-page">
   <div class="narrow">
-    <h2>{{projectSettings.title}}</h2>
+    <h1>{{projectSettings.title}}</h1>
     <p class="large-text">
       {{projectSettings.description}}
     </p>
@@ -16,4 +16,4 @@ permalink: /projects/
     {% set projectlist = collections.projects %}
     {% include "components/projectList.njk" %}
   </div>
-</p>
+</div>

--- a/web/services.njk
+++ b/web/services.njk
@@ -4,7 +4,7 @@ navtitle: Services
 permalink: /services/
 ---
 
-<article class="narrow page">
+<article class="narrow page services-page">
     <h1>{{services.title}}</h1>
 
     {{ services.body | markdownify | safe }}

--- a/web/utils/serializers.js
+++ b/web/utils/serializers.js
@@ -16,8 +16,20 @@ module.exports = {
       return `![${node.alt}](${imageUrl(node).url()})`;
     },
     file: ({node}) => '',
-    video: ({node}) => `VIDEO: <iframe width="100%" height="400px" src="${node.href}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`,
+    video: ({node}) => `<iframe width="100%" height="400px" src="${node.href}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>`,
     audio: ({node}) => `<iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/${node.code}&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>`,
-    embed: ({node}) => `${node.code}`
+    embed: ({node}) => `${node.code}`,
+    highlighted: ({node}) => {
+      let list = ``;
+      node.list.forEach(item => {
+        list += `<li>${item}</li>`;
+      });
+      list = `<ul>${list}</ul>`
+
+      return `<div class="highlighted">
+        <h3>${node.title}</h3>
+        ${list}
+      </div>`;
+    }
   }
 }


### PR DESCRIPTION
This update adds:
- Block to highlight lists in the editor
  - Optional title + required list (at least one item)
  - In a future update, it will be possible to:
     - Customize the color
     - Add text in addition to, or instead of, lists
- Title redesign
  - Blog posts and projects have a `<h2>` highlight in the same color as the font
  - Service page has a `<h2>` in the main brand color
  - All main titles (aside from the homepage) are now the same size and have the same position
- Small UX updates to sanity: custom blocks now have actual matching icons